### PR TITLE
fix staticfiles dir doesn't exist for local development

### DIFF
--- a/bugbountytube/bugbountytube/settings.py
+++ b/bugbountytube/bugbountytube/settings.py
@@ -23,7 +23,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'django-insecure-bym030g!9%ywrl^qxzhcfh=6o448g^(_+gq=m(m%8l^k67jh@2'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = True
 
 ALLOWED_HOSTS = ['*']
 

--- a/bugbountytube/bugbountytube/urls.py
+++ b/bugbountytube/bugbountytube/urls.py
@@ -13,6 +13,8 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+from django.conf import settings
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import path, include
 
@@ -21,5 +23,7 @@ urlpatterns = [
     path('', include('videos.urls')),
     path('grappelli/', include('grappelli.urls')), # grappelli URLS
     path('markdownx/', include('markdownx.urls')),
-
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
## Proposed Changes

1. In `settings.py`, the `DEBUG` setting has been changed to `True`. This change enables debugging mode, which is typically used during development and should not be active in a production environment for security reasons.

2. In `urls.py`, the code has been updated to handle static files during development. It imports settings and adds a URL pattern for serving static files when `DEBUG` mode is enabled. This allows static files like CSS, JavaScript, and images to be served directly by Django during development.

These changes appear to be aimed at improving the development experience and are suitable for non-production environments where debugging and serving static files directly are common practices.